### PR TITLE
Added missing macro guard to build without Streamline

### DIFF
--- a/sl_demo/DemoMain.cpp
+++ b/sl_demo/DemoMain.cpp
@@ -91,9 +91,9 @@ using namespace donut::render;
 constexpr float OPTIMAL_RATIO  = -1.0f; // Use the scaling ratio that the DLSS recommends
 constexpr size_t NUM_OFFSET_SEQUENCES = 64; // Use a large number of Halton sequence offsets to accomodate large scaling ratios.
 
-enum class AntiAliasingMode { 
-    NONE, 
-    TEMPORAL, 
+enum class AntiAliasingMode {
+    NONE,
+    TEMPORAL,
 #ifdef USE_SL
     DLSS,
 #endif
@@ -186,7 +186,9 @@ private:
 
     UIData&                             m_ui;
 
+#if USE_SL
     SLWrapper::DLSSSettings            m_RecommendedSettings;
+#endif
 
     int2                               renderingRectSize = { 0, 0 };
     float                              dynamicResizeTime = 0.0f;
@@ -209,10 +211,10 @@ public:
 #if USE_SL
         m_SLWrapper = std::make_unique<SLWrapper>(GetDevice());
         m_ui.DLSS_Supported = m_SLWrapper->GetDLSSAvailable();
-#endif
 
         if (m_ui.DLSS_Supported) log::info("DLSS is supported on this system.");
         else log::warning("DLSS is not supported on this system.");
+#endif
 
         std::shared_ptr<NativeFileSystem> nativeFS = std::make_shared<NativeFileSystem>();
 
@@ -772,11 +774,11 @@ public:
             m_ToneMappingPass->ResetExposure(m_CommandList, 8.f);
 
         // GBuffer Pass
-        RenderCompositeView(m_CommandList, 
-            m_View.get(), m_ViewPrevious.get(), 
-            *m_RenderTargets->m_GBufferFramebuffer, 
-            *m_OpaqueDrawStrategy, 
-            *m_GBufferPass, 
+        RenderCompositeView(m_CommandList,
+            m_View.get(), m_ViewPrevious.get(),
+            *m_RenderTargets->m_GBufferFramebuffer,
+            *m_OpaqueDrawStrategy,
+            *m_GBufferPass,
             "GBufferFill",
             m_ui.EnableMaterialEvents);
 
@@ -858,7 +860,7 @@ public:
             if (m_ui.AAMode ==AntiAliasingMode::DLSS)
             {
                 m_SLWrapper->EvaluateDLSS(m_CommandList,
-                    m_RenderTargets->m_ResolvedColor, 
+                    m_RenderTargets->m_ResolvedColor,
                     renderColor,
                     m_RenderTargets->m_MotionVectors,
                     m_RenderTargets->m_Depth,
@@ -910,9 +912,9 @@ public:
 
             AdvanceFrame();
 
-            GetDeviceManager()->SetVsyncEnabled(m_ui.EnableVsync); 
+            GetDeviceManager()->SetVsyncEnabled(m_ui.EnableVsync);
         }
-        
+
     }
 
     std::shared_ptr<ShaderFactory> GetShaderFactory()
@@ -1023,6 +1025,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     SLWrapper::Shutdown();
 #endif
 
-    
+
     return 0;
 }

--- a/sl_demo/glue/UIRenderer.h
+++ b/sl_demo/glue/UIRenderer.h
@@ -100,8 +100,8 @@ protected:
         ImGui::Text("API: %s", name.c_str());
 
         ImGui::Separator();
-        ImGui::Text("DLSS_Supported: %s", m_ui.DLSS_Supported ? "yes":"no");
 #ifdef USE_SL
+        ImGui::Text("DLSS_Supported: %s", m_ui.DLSS_Supported ? "yes":"no");
         ImGui::Combo("AA Mode", (int*)&m_ui.AAMode, "None\0TemporalAA\0DLSS\0");
 #else
         ImGui::Combo("AA Mode", (int*)&m_ui.AAMode, "None\0TemporalAA\0");

--- a/sl_demo/secureLoadLibrary.cpp
+++ b/sl_demo/secureLoadLibrary.cpp
@@ -18,7 +18,7 @@
 * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 * SOFTWARE.
-*/ 
+*/
 #define SL_WINDOWS
 #ifdef SL_WINDOWS
 
@@ -41,7 +41,9 @@
 
 #include <inttypes.h>
 
+#if USE_SL
 #include "sl.h"
+#endif
 #include <donut/core/log.h>
 
 //#include "source/core/sl.log/log.h"
@@ -185,7 +187,7 @@ bool isSignedByNVIDIA(const wchar_t* pathToFile)
     HCRYPTMSG hMsg = NULL;
     PCMSG_SIGNER_INFO pSignerInfo = NULL;
     DWORD dwSignerInfo;
-    
+
     if (!pfnCertOpenStore)
     {
         // We only support Win10+ so we can search for module in system32 directly
@@ -441,15 +443,15 @@ bool verifyEmbeddedSignature(const wchar_t* pathToFile)
     WinTrustData.hWVTStateData = NULL;
     // Not used.
     WinTrustData.pwszURLReference = NULL;
-    // This is not applicable if there is no UI because it changes 
-    // the UI to accommodate running applications instead of 
+    // This is not applicable if there is no UI because it changes
+    // the UI to accommodate running applications instead of
     // installing applications.
     WinTrustData.dwUIContext = 0;
     // Set pFile.
     WinTrustData.pFile = &FileData;
 
     // First verify the primary signature (index 0) to determine how many secondary signatures
-    // are present. We use WSS_VERIFY_SPECIFIC and dwIndex to do this, also setting 
+    // are present. We use WSS_VERIFY_SPECIFIC and dwIndex to do this, also setting
     // WSS_GET_SECONDARY_SIG_COUNT to have the number of secondary signatures returned.
     WINTRUST_SIGNATURE_SETTINGS SignatureSettings = {};
     CERT_STRONG_SIGN_PARA StrongSigPolicy = {};
@@ -465,7 +467,7 @@ bool verifyEmbeddedSignature(const wchar_t* pathToFile)
 
     // WinVerifyTrust verifies signatures as specified by the GUID  and Wintrust_Data.
     lStatus = pfnWinVerifyTrust(NULL, &WVTPolicyGUID, &WinTrustData);
-    
+
     // First signature must be validated by the OS
     valid = lStatus == ERROR_SUCCESS;
     if (!valid)


### PR DESCRIPTION
# Issue
When trying to build without Streamline by turning off the "Use SL integration" option within CMake, the project outputs errors due to missing/misplaced macro guards. This is a problem for developers that wish to reproduce and report Streamline issues on the sample.

# How to reproduce
Simply head over to ``donut/CMakeLists.txt`` and try to build with said option turned off:
```cmake
option(DONUT_WITH_SL "Use SL integration" OFF)
```

# Solution
I fixed the macro guards around the remaining Streamline-related code that was preventing the sample from building.
This fix was tested under Windows 10 19044 using MSVC 2019 16.9.6 for the x64 architecture.